### PR TITLE
Fire pixel when ad is in viewport

### DIFF
--- a/views/components/Ad.jsx
+++ b/views/components/Ad.jsx
@@ -53,8 +53,6 @@ class Ad extends React.Component {
   }
 
   componentDidMount () {
-    var ctx = this;
-
     this.getAd().then((ad) => {
       this.adObject = new models.Link(ad).toJSON();
       return this.setState({


### PR DESCRIPTION
:eyeglasses: @ajacksified 

Pursuant to [JIRA #171](https://reddit.atlassian.net/browse/ADS-171):
1. Tracks position of ad unit
2. When center point of ad unit is within the viewport, fire pixel tracker
3. Make impression request by assigning `src` attribute on JS image rather than embedding tag

Scroll tracking calculations and handlers based on code by @danehansen.
